### PR TITLE
Minor Suggestions on Version Compare and Service Check

### DIFF
--- a/check_lmcontroller_service.ps1
+++ b/check_lmcontroller_service.ps1
@@ -1,16 +1,20 @@
-$check_service = get-service "ImControllerservice" -ea silentlycontinue
+
+$patchedVersion = [Version]"1.1.20.3"
+
+$check_service = Get-Service "ImControllerservice" -ea silentlycontinue
+
 If($check_service -ne $null)
 	{
 		$Controller_Path = "C:\Windows\Lenovo\ImController\PluginHost\Lenovo.Modern.ImController.PluginHost.exe"
 		If(test-path $Controller_Path)
 			{
-				$Get_Version = (get-item $Controller_Path | select *).VersionInfo.ProductVersion
-				If($Get_Version -lt "1.1.20.3")
+				[Version]$Get_Version = (get-item $Controller_Path | select *).VersionInfo.ProductVersion
+				If($Get_Version -lt $patchedVersion)
 					{
 						write-output "Service installed and bad version ($Get_Version)"	  
 						EXIT 1					
 					}
-				ElseIf($Get_Version -ge "1.1.20.3")
+				ElseIf($Get_Version -ge $patchedVersion)
 					{
 						write-output "Service installed but version OK ($Get_Version)"	  
 						EXIT 0				

--- a/check_lmcontroller_service.ps1
+++ b/check_lmcontroller_service.ps1
@@ -1,25 +1,21 @@
 
 $patchedVersion = [Version]"1.1.20.3"
 
-$check_service = Get-Service "ImControllerservice" -ea silentlycontinue
+$check_service = Get-CimInstance Win32_Service -Filter "Name = 'ImControllerservice'" -Property PathName
 
 If($check_service -ne $null)
 	{
-		$Controller_Path = "C:\Windows\Lenovo\ImController\PluginHost\Lenovo.Modern.ImController.PluginHost.exe"
-		If(test-path $Controller_Path)
+		[Version]$Get_Version = (get-item $Controller_Path | select *).VersionInfo.ProductVersion
+		If($Get_Version -lt $patchedVersion)
 			{
-				[Version]$Get_Version = (get-item $Controller_Path | select *).VersionInfo.ProductVersion
-				If($Get_Version -lt $patchedVersion)
-					{
-						write-output "Service installed and bad version ($Get_Version)"	  
-						EXIT 1					
-					}
-				ElseIf($Get_Version -ge $patchedVersion)
-					{
-						write-output "Service installed but version OK ($Get_Version)"	  
-						EXIT 0				
-					}					
+				write-output "Service installed and bad version ($Get_Version)"	  
+				EXIT 1					
 			}
+		ElseIf($Get_Version -ge $patchedVersion)
+			{
+				write-output "Service installed but version OK ($Get_Version)"	  
+				EXIT 0				
+			}					
 	}
 Else
 	{


### PR DESCRIPTION
Hi @damienvanrobaeys, great idea for this one, thanks! Made a few suggestions:

- Changed the version comparison from string (which works in many, but not all cases) to use `[Version]` so you get a true version comparison.
- Instead of hard coding the path to the EXE, grabbed it from WMI and used that path instead.  This way you won't need to worry about if the file is installed somewhere else for their systemroot is different.